### PR TITLE
do not save shuffled numbers to temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.idea/


### PR DESCRIPTION
Make creating of the file with random numbers faster by getting rid of unneeded step - saving shuffled chunks to temp files and reading them again to write out to the final file

Also write out each number to random chunk instead of using module in order to randomize numbers better